### PR TITLE
Correctly check for alias in CsrfTokenManagerPass

### DIFF
--- a/src/Bundle/DependencyInjection/Compiler/CsrfTokenManagerPass.php
+++ b/src/Bundle/DependencyInjection/Compiler/CsrfTokenManagerPass.php
@@ -27,7 +27,7 @@ final class CsrfTokenManagerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container) : void
     {
-        if ($container->hasDefinition('contao.csrf.token_manager')) {
+        if ($container->hasAlias('contao.csrf.token_manager')) {
             $container->setAlias('netzmacht.contao_toolkit.csrf.token_manager', 'contao.csrf.token_manager');
         } else {
             $container->setAlias('netzmacht.contao_toolkit.csrf.token_manager', 'security.csrf.token_manager');


### PR DESCRIPTION
Fixes #27

Since https://github.com/contao/contao/pull/3214/commits/094727d51cbdb0a96b1f317dad790bc0bf51745d#diff-4f61af5b7b80f582bc48e99f6a255466348bd04545a357355b630f9892259488 the Contao CSRF Token Manager is registered with the FQCN. It still is available via the old alias `contao.csrf.token_manager`. 